### PR TITLE
Fix: Auto-assign admin role to group conversation creator

### DIFF
--- a/backend/test/support/fixtures/chat_fixtures.ex
+++ b/backend/test/support/fixtures/chat_fixtures.ex
@@ -17,7 +17,7 @@ defmodule Famichat.ChatFixtures do
       conv = ChatFixtures.conversation_fixture()
   """
 
-  alias Famichat.Chat.{Conversation, ConversationParticipant}
+  alias Famichat.Chat.{Conversation, ConversationParticipant, ConversationService}
   alias Famichat.Repo
 
   @doc """
@@ -174,8 +174,24 @@ defmodule Famichat.ChatFixtures do
     conversation
   end
 
+  defp create_conversation_by_type(%{conversation_type: :group} = attrs) do
+    user = user_fixture(%{family_id: attrs.family_id})
+    group_name = Map.get(attrs.metadata, "name", "Test Group Conversation")
+
+    {:ok, conversation} =
+      ConversationService.create_group_conversation(
+        user.id,
+        attrs.family_id,
+        group_name,
+        attrs.metadata
+      )
+
+    conversation
+  end
+
   defp create_conversation_by_type(attrs) do
-    # For other conversation types (group, etc.)
+    # For other conversation types (e.g. :self, if added later)
+    # This will now only handle types not explicitly matched above.
     user = user_fixture(%{family_id: attrs.family_id})
 
     conversation = create_base_conversation(attrs)


### PR DESCRIPTION
Previously, the creator of a group conversation was not automatically assigned administrator privileges within the ConversationService. A test meant to cover this functionality was passing due to manual data setup in the test itself, which masked this omission.

This commit introduces the following changes:

1.  New `ConversationService.create_group_conversation/4` function: This function now handles the creation of group conversations. Within a database transaction, it creates the conversation, adds the creator as a participant, and crucially, inserts a `GroupConversationPrivileges` record making the creator an admin of the group.

2.  Updated `conversation_fixture`: The fixture for creating conversations now calls the new `create_group_conversation/4` service function when a `:group` type conversation is requested. This ensures test data accurately reflects service behavior.

3.  Revised Tests in `conversation_service_test.exs`:
    - The manual insertion of admin privileges for the creator in the test setup for group privilege management has been removed.
    - The test "auto-assigns creator as admin..." now correctly verifies that the actual creator (via the updated fixture) is made an admin by the service.
    - Adjustments were made to ensure other tests relying on an admin user for performing actions continue to function correctly.

This change ensures that the system behaves as intuitively expected, with group creators automatically having administrative rights over their conversations, and that this behavior is accurately tested.